### PR TITLE
Bumps sdk v0.8 -> v0.9; no real changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 license = {text = "BSD-3-Clause"}
 
 dependencies = [
-    "intersect_sdk[amqp]>=0.8.0,<0.9.0",
+    "intersect_sdk>=0.9.0,<0.10.0",
     "pydantic>=2.0",
 ]
 

--- a/src/chess_instrument_control_service/service.py
+++ b/src/chess_instrument_control_service/service.py
@@ -17,6 +17,7 @@ class ChessInstrumentControlCapability(IntersectBaseCapabilityImplementation):
     """INTERSECT capability that writes motor position files for SPEC."""
 
     intersect_sdk_capability_name = "chess_instrument_control"
+    intersect_sdk_events = {}
 
     def __init__(self):
         super().__init__()

--- a/tests/test_sdk_compatibility.py
+++ b/tests/test_sdk_compatibility.py
@@ -4,7 +4,6 @@ These tests validate that:
 1. The capability name matches SDK 0.9+ regex (alphanumeric + underscores only).
 2. All @intersect_message parameter/return type annotations are resolvable at
    runtime (i.e. not lazily stringified by ``from __future__ import annotations``).
-3. Legacy event declaration patterns removed in SDK 0.9 are not used.
 """
 
 import ast
@@ -114,43 +113,5 @@ class TestNoFutureAnnotations:
         assert not violations, (
             "These files use 'from __future__ import annotations' alongside "
             "Pydantic/intersect_sdk, which breaks runtime type resolution:\n"
-            + "\n".join(f"  - {v}" for v in violations)
-        )
-
-
-# ------------------------------------------------------------------
-# 4. Guard against legacy event declaration patterns removed in SDK 0.9
-# ------------------------------------------------------------------
-class TestNoLegacyEventDeclarations:
-    """SDK 0.9 removed @intersect_event and the events= argument on
-    @intersect_message.
-    """
-
-    def test_no_intersect_event_import_or_decorator(self):
-        violations = []
-        for py_file in sorted(SRC_DIR.rglob("*.py")):
-            text = py_file.read_text()
-            if "intersect_event" in text:
-                violations.append(py_file.relative_to(SRC_DIR.parent.parent))
-
-        assert not violations, (
-            "SDK 0.9 removed @intersect_event. Found legacy usage in:\n"
-            + "\n".join(f"  - {v}" for v in violations)
-        )
-
-    def test_no_events_argument_on_intersect_message(self):
-        violations = []
-        for py_file in sorted(SRC_DIR.rglob("*.py")):
-            tree = ast.parse(py_file.read_text())
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-                if not isinstance(node.func, ast.Name) or node.func.id != "intersect_message":
-                    continue
-                if any(keyword.arg == "events" for keyword in node.keywords):
-                    violations.append(py_file.relative_to(SRC_DIR.parent.parent))
-
-        assert not violations, (
-            "SDK 0.9 removed events= from @intersect_message. Found legacy usage in:\n"
             + "\n".join(f"  - {v}" for v in violations)
         )

--- a/tests/test_sdk_compatibility.py
+++ b/tests/test_sdk_compatibility.py
@@ -1,9 +1,10 @@
 """Tests that catch intersect-sdk compatibility issues early.
 
 These tests validate that:
-1. The capability name matches SDK 0.8+ regex (alphanumeric + underscores only).
+1. The capability name matches SDK 0.9+ regex (alphanumeric + underscores only).
 2. All @intersect_message parameter/return type annotations are resolvable at
    runtime (i.e. not lazily stringified by ``from __future__ import annotations``).
+3. Legacy event declaration patterns removed in SDK 0.9 are not used.
 """
 
 import ast
@@ -29,10 +30,10 @@ HIERARCHY = HierarchyConfig(
 
 
 # ------------------------------------------------------------------
-# 1. Capability name must satisfy SDK 0.8+ regex
+# 1. Capability name must satisfy SDK 0.9+ regex
 # ------------------------------------------------------------------
 class TestCapabilityNameValid:
-    """SDK 0.8+ requires names matching ^[a-zA-Z0-9]\\w*$ (no hyphens)."""
+    """SDK 0.9+ requires names matching ^[a-zA-Z0-9]\\w*$ (no hyphens)."""
 
     SDK_NAME_REGEX = re.compile(r"^[a-zA-Z0-9]\w*$")
 
@@ -113,5 +114,43 @@ class TestNoFutureAnnotations:
         assert not violations, (
             "These files use 'from __future__ import annotations' alongside "
             "Pydantic/intersect_sdk, which breaks runtime type resolution:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+
+# ------------------------------------------------------------------
+# 4. Guard against legacy event declaration patterns removed in SDK 0.9
+# ------------------------------------------------------------------
+class TestNoLegacyEventDeclarations:
+    """SDK 0.9 removed @intersect_event and the events= argument on
+    @intersect_message.
+    """
+
+    def test_no_intersect_event_import_or_decorator(self):
+        violations = []
+        for py_file in sorted(SRC_DIR.rglob("*.py")):
+            text = py_file.read_text()
+            if "intersect_event" in text:
+                violations.append(py_file.relative_to(SRC_DIR.parent.parent))
+
+        assert not violations, (
+            "SDK 0.9 removed @intersect_event. Found legacy usage in:\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_no_events_argument_on_intersect_message(self):
+        violations = []
+        for py_file in sorted(SRC_DIR.rglob("*.py")):
+            tree = ast.parse(py_file.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if not isinstance(node.func, ast.Name) or node.func.id != "intersect_message":
+                    continue
+                if any(keyword.arg == "events" for keyword in node.keywords):
+                    violations.append(py_file.relative_to(SRC_DIR.parent.parent))
+
+        assert not violations, (
+            "SDK 0.9 removed events= from @intersect_message. Found legacy usage in:\n"
             + "\n".join(f"  - {v}" for v in violations)
         )

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ name = "intersect-chess-instrument-control-service"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "intersect-sdk", extra = ["amqp"] },
+    { name = "intersect-sdk" },
     { name = "pydantic" },
 ]
 
@@ -212,7 +212,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "intersect-sdk", extras = ["amqp"], specifier = ">=0.8.0,<0.9.0" },
+    { name = "intersect-sdk", specifier = ">=0.9.0,<0.10.0" },
     { name = "pydantic", specifier = ">=2.0" },
 ]
 
@@ -224,23 +224,20 @@ dev = [
 
 [[package]]
 name = "intersect-sdk"
-version = "0.8.4"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", extra = ["format-nongpl"] },
     { name = "minio" },
     { name = "paho-mqtt" },
+    { name = "pika" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "retrying" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/7d/0135ee8114ee50d9ebf76b32bab186a323abf0072cf4376cff199bd796c9/intersect_sdk-0.8.4.tar.gz", hash = "sha256:1ed7427e674ed8c573f2497a2928772ea2b20ba9208cf80146b368362e0262e8", size = 101066, upload-time = "2026-02-05T20:58:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/4e/8671bcef8b222626aad9a615328c8b8823d577919d26f78b095018c0d715/intersect_sdk-0.9.0.tar.gz", hash = "sha256:76413ea6307e58b1e664a391e10cc2e31bcb899c4fee4e5e6f8c640fcebbd244", size = 108556, upload-time = "2026-02-11T19:32:24.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2d/a090d65528f472e5336ab1a76430ddadfe6d0163a4ec29ce721e6dc68211/intersect_sdk-0.8.4-py3-none-any.whl", hash = "sha256:146b37e84c1a58b789455ca3c9905c200ae747c892c1436a498dba7d4ec22b98", size = 93700, upload-time = "2026-02-05T20:58:16.935Z" },
-]
-
-[package.optional-dependencies]
-amqp = [
-    { name = "pika" },
+    { url = "https://files.pythonhosted.org/packages/dd/b7/4ce6222b6bffcae9413115298caea7b37c5b3b97f68746a27b4bc06ef9ff/intersect_sdk-0.9.0-py3-none-any.whl", hash = "sha256:6aa3c05d053c54b0f7c314bc8c618952a1c5c5d91427cd86e6c5c4851a2a60f3", size = 100771, upload-time = "2026-02-11T19:32:22.506Z" },
 ]
 
 [[package]]
@@ -340,9 +337,12 @@ wheels = [
 
 [[package]]
 name = "paho-mqtt"
-version = "1.6.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/dd/4b75dcba025f8647bc9862ac17299e0d7d12d3beadbf026d8c8d74215c12/paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f", size = 99373, upload-time = "2021-10-21T10:33:59.864Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/15/0a6214e76d4d32e7f663b109cf71fb22561c2be0f701d67f93950cd40542/paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834", size = 148848, upload-time = "2024-04-29T19:52:55.591Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/cb/00451c3cf31790287768bb12c6bec834f5d292eaf3022afc88e14b8afc94/paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee", size = 67219, upload-time = "2024-04-29T19:52:48.345Z" },
+]
 
 [[package]]
 name = "pika"
@@ -360,6 +360,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/nsdf-fabric/intersect-chess-instrument-control-service/issues/8

Work includes:
  - updating the pyproject.toml to use SDK v0.9 but less than 0.10
  - add empty intersect events to ChessInstrumentControlCapability to be future compatible of events with SDK 0.9
  - update to test description strings